### PR TITLE
补充成就"四维碎块"的说明

### DIFF
--- a/assets/minecraft/lang/zh_meme.json
+++ b/assets/minecraft/lang/zh_meme.json
@@ -128,7 +128,7 @@
     "advancements.nether.distract_piglin.title": "金光闪闪",
     "advancements.nether.explore_nether.description": "探索所有尼德兰的生物群系",
     "advancements.nether.explore_nether.title": "热门景点",
-    "advancements.nether.fast_travel.description": "利用尼德兰移动对应主世界千米的距离",
+    "advancements.nether.fast_travel.description": "利用尼德兰移动对应主世界7千米的距离",
     "advancements.nether.fast_travel.title": "次元旅行",
     "advancements.nether.find_bastion.description": "进入猪刚鬣之家",
     "advancements.nether.find_bastion.title": "光辉岁月",


### PR DESCRIPTION
## 提请合并

更改成就"次元旅行(四维碎块)"的说明(原翻译无说明需移动几千米)

** Minecraft 原版 **
